### PR TITLE
Add bundle bootboot command to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ To start, run:
 
 ```
 $ bundle install
+$ bundle bootboot
 ```
 
 This should create `Gemfile.lock` and `Gemfile_next.lock` files for you, but it


### PR DESCRIPTION
It seems that `bundle bootboot` is what adds the Gemfile_next.lock. I was running into an error from bundler about a missing Gemfile_next.lock until I ran that.